### PR TITLE
 Updated the tenstorrent-hugepages.service to run before sysinit.target

### DIFF
--- a/tenstorrent-hugepages.service
+++ b/tenstorrent-hugepages.service
@@ -1,10 +1,10 @@
 [Unit]
 Description=Script that configures hugepages for Tenstorrent ASICs
-After=multi-user.target dev-hugepages\x2d1G.mount
-Requires=dev-hugepages\x2d1G.mount
+Before=sysinit.target
+DefaultDependencies=no
 
 [Service]
-Type=simple
+Type=oneshot
 ExecStart=/opt/tenstorrent/bin/hugepages-setup.sh
 User=root
 Restart=no
@@ -12,4 +12,4 @@ SuccessExitStatus=0
 TimeoutStopSec=10s
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=sysinit.target


### PR DESCRIPTION
## Summary
This MR is a result of an issue the cloud team was facing when deploying this service to our Kubernetes cluster. 

In it's current state the service does not guarantee having all hugepages allocated before any dependent services like `kubelet.service`. Hence when the host would be rebooted the kubelet service would only catch partial hugepages.

To fix this issue we moved this service much earlier in the bootup process to before sysinit.target. Reference: https://www.freedesktop.org/software/systemd/man/latest/bootup.html.

## Changes Made:
1. Change hugepages service to start before sysinit.target
2. Change service type to oneshot. "Behavior of oneshot is similar to simple; however, the service manager will consider the unit up after the main process exits. It will then start follow-up units". Reference: https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Options.
3. Remove default dependencies and dev-hugepage mount dependency