### PR TITLE
+link to usage page

### DIFF
--- a/hugepages-setup/README.md
+++ b/hugepages-setup/README.md
@@ -30,3 +30,7 @@ If you need to override the default number of hugepages, create a text file at `
 - Root privileges for the initial setup
 - hugetlbfs kernel support
 - pciutils package installed
+
+## Usage
+
+See https://docs.tenstorrent.com/getting-started/manual-software-install.html#step-4-set-up-hugepages .


### PR DESCRIPTION
Some documents link here for hugepage setup. I'd like to add a link to the usage page to better guide users.