### PR TITLE
fix: add to the existing hugepage allocation instead of replacing it

### DIFF
--- a/hugepages-setup/hugepages-setup.sh
+++ b/hugepages-setup/hugepages-setup.sh
@@ -60,21 +60,56 @@ fi
 # hugepages.
 NODES=${!nodes[*]}
 
+# Overridable so the allocation logic can be exercised against a fixture
+# instead of the live system.
+SYSFS_ROOT="${SYSFS_ROOT:-/sys}"
+
+# How many pages we added, per node, so a re-run reconciles instead of
+# stacking. /run is tmpfs and is cleared on boot, which is exactly when
+# nr_hugepages resets too, so the marker and the kernel state expire together.
+STATE_DIR="${STATE_DIR:-/run/tenstorrent}"
+
 # First, make sure we have the hugepages configured and available.
 for n in $NODES ; do
-    NODEDIR="/sys/devices/system/node/node${n}"
+    NODEDIR="${SYSFS_ROOT}/devices/system/node/node${n}"
     [ -d "${NODEDIR}" ] || error_out "Can't locate numa node directory at $NODEDIR. Check setup."
     HUGEPAGE_DIR="${NODEDIR}/hugepages/hugepages-1048576kB"
     [ -d "${HUGEPAGE_DIR}" ] || error_out "Can't locate 1GB hugepage settings at ${HUGEPAGE_DIR}. Check setup."
 
     NR_HP="$(cat "${HUGEPAGE_DIR}/nr_hugepages")"
+
+    # Whatever is already allocated belongs to something else - a VM backed by
+    # 1G pages, for instance - so add our requirement on top rather than
+    # replacing it. Subtract what we added ourselves earlier this boot so that
+    # running the script twice converges instead of growing.
+    STATE_FILE="${STATE_DIR}/hugepages-added-node${n}"
+    PREV_ADDED=0
+    if [ -f "${STATE_FILE}" ] ; then
+        PREV_ADDED="$(cat "${STATE_FILE}")"
+        [[ "${PREV_ADDED}" =~ ^[0-9]+$ ]] || PREV_ADDED=0
+    fi
+
+    BASELINE=$((NR_HP - PREV_ADDED))
+    # Guard against the count having been lowered behind our back.
+    [ "${BASELINE}" -lt 0 ] && BASELINE=0
+
+    TARGET=$((BASELINE + nodes[$n]))
+
     echo "Node ${n} hugepages before: ${NR_HP}"
     echo "Node ${n} hugepages needed: ${nodes[$n]}"
-    echo "${nodes[$n]}" > "${HUGEPAGE_DIR}/nr_hugepages" || error_out "Can't write to hugepages file at ${HUGEPAGE_DIR}/nr_hugepages"
+    echo "Node ${n} hugepages already in use by others: ${BASELINE}"
+    echo "Node ${n} hugepages target: ${TARGET}"
+
+    echo "${TARGET}" > "${HUGEPAGE_DIR}/nr_hugepages" || error_out "Can't write to hugepages file at ${HUGEPAGE_DIR}/nr_hugepages"
     NR_HP="$(cat "${HUGEPAGE_DIR}/nr_hugepages")"
     echo "Node ${n} hugepages after: ${NR_HP}"
-    if [ "${NR_HP}" != "${nodes[$n]}" ] ; then
-        error_out "Failed to get requested ${nodes[$n]} hugepages, only got ${NR_HP}"
+    if [ "${NR_HP}" != "${TARGET}" ] ; then
+        error_out "Failed to get requested ${TARGET} hugepages, only got ${NR_HP}"
+    fi
+
+    # Record our contribution only once the kernel has honoured it.
+    if mkdir -p "${STATE_DIR}" 2>/dev/null ; then
+        echo "${nodes[$n]}" > "${STATE_FILE}" || true
     fi
 done
 

--- a/hugepages-setup/test-hugepages-setup.sh
+++ b/hugepages-setup/test-hugepages-setup.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for hugepage allocation arithmetic (issue #15).
+#
+# The script used to write the number of pages Tenstorrent needs straight into
+# nr_hugepages, which discards whatever the machine had already been configured
+# with - a VM backed by 1G pages, for example. These cover adding on top of an
+# existing allocation and converging on a re-run rather than stacking.
+#
+# Runs against a fixture sysfs tree and a stub lspci, so no Tenstorrent
+# hardware and no root are needed.
+#
+# Usage: hugepages-setup/test-hugepages-setup.sh
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${HERE}/hugepages-setup.sh"
+[ -x "${SCRIPT}" ] || [ -f "${SCRIPT}" ] || { echo "cannot find hugepages-setup.sh" >&2; exit 1; }
+
+PASS=0
+FAIL=0
+
+check() {
+	local desc="$1" expected="$2" actual="$3"
+	if [[ "${expected}" == "${actual}" ]] ; then
+		PASS=$((PASS + 1))
+	else
+		FAIL=$((FAIL + 1))
+		echo "FAIL: ${desc} - expected ${expected}, got ${actual}"
+	fi
+}
+
+# Build a fixture: one NUMA node preloaded with `existing` 1G pages, and an
+# lspci that reports `cards` Wormholes on node 0.
+make_fixture() {
+	local existing="$1" cards="$2"
+	FIXTURE="$(mktemp -d)"
+	local hp="${FIXTURE}/sys/devices/system/node/node0/hugepages/hugepages-1048576kB"
+	mkdir -p "${hp}"
+	echo "${existing}" > "${hp}/nr_hugepages"
+	echo "${existing}" > "${hp}/free_hugepages"
+
+	mkdir -p "${FIXTURE}/bin"
+	{
+		echo '#!/usr/bin/env bash'
+		# -vmm output: one stanza per device, blank-line separated, as the
+		# script's awk expects. Only the WH id yields devices.
+		echo 'if [[ "$*" == *"401e"* ]] ; then'
+		echo "  for i in \$(seq 1 ${cards}) ; do"
+		echo '    printf "Slot:\t00:01.0\nNUMANode:\t0\n\n"'
+		echo '  done'
+		echo 'fi'
+		echo 'exit 0'
+	} > "${FIXTURE}/bin/lspci"
+	chmod +x "${FIXTURE}/bin/lspci"
+
+	NR_FILE="${hp}/nr_hugepages"
+	STATE="${FIXTURE}/run"
+}
+
+run_script() {
+	PATH="${FIXTURE}/bin:${PATH}" \
+	SYSFS_ROOT="${FIXTURE}/sys" \
+	STATE_DIR="${STATE}" \
+		bash "${SCRIPT}" >/dev/null 2>&1
+	return $?
+}
+
+# ---- a machine with nothing configured ----------------------------------
+make_fixture 0 1
+run_script
+check "fresh machine, one WH gets 4 pages" "4" "$(cat "${NR_FILE}")"
+rm -rf "${FIXTURE}"
+
+make_fixture 0 2
+run_script
+check "fresh machine, two WH get 8 pages" "8" "$(cat "${NR_FILE}")"
+rm -rf "${FIXTURE}"
+
+# ---- the bug in #15: an existing allocation must survive -----------------
+make_fixture 32 1
+run_script
+check "existing 32 pages are kept, not replaced" "36" "$(cat "${NR_FILE}")"
+rm -rf "${FIXTURE}"
+
+make_fixture 32 2
+run_script
+check "existing 32 pages plus two cards" "40" "$(cat "${NR_FILE}")"
+rm -rf "${FIXTURE}"
+
+# ---- re-running must converge, not stack --------------------------------
+make_fixture 32 1
+run_script
+first="$(cat "${NR_FILE}")"
+run_script
+check "second run does not add again" "${first}" "$(cat "${NR_FILE}")"
+run_script
+check "third run does not add again" "${first}" "$(cat "${NR_FILE}")"
+rm -rf "${FIXTURE}"
+
+make_fixture 0 1
+run_script
+run_script
+check "re-run on a fresh machine stays at 4" "4" "$(cat "${NR_FILE}")"
+rm -rf "${FIXTURE}"
+
+# ---- a fresh boot clears the marker, and the count has reset too --------
+make_fixture 32 1
+run_script
+rm -rf "${STATE}"          # /run is tmpfs; boot clears it
+echo 32 > "${NR_FILE}"     # nr_hugepages resets to the cmdline value
+run_script
+check "after a reboot the machine lands on the same total" "36" "$(cat "${NR_FILE}")"
+rm -rf "${FIXTURE}"
+
+# ---- someone lowered the count behind our back --------------------------
+make_fixture 32 1
+run_script
+echo 2 > "${NR_FILE}"      # now below what we recorded as ours
+run_script
+check "a lowered count does not produce a negative target" "4" "$(cat "${NR_FILE}")"
+rm -rf "${FIXTURE}"
+
+# ---- the script still fails loudly when the node is missing -------------
+make_fixture 0 1
+rm -rf "${FIXTURE}/sys/devices/system/node/node0"
+run_script
+check "missing numa node is still an error" "1" "$?"
+rm -rf "${FIXTURE}"
+
+echo
+echo "${PASS} passed, ${FAIL} failed"
+[[ "${FAIL}" -eq 0 ]]


### PR DESCRIPTION
Fixes #15

The script wrote the number of pages Tenstorrent needs straight into `nr_hugepages`, so a machine already configured with 1G pages for something else had that allocation discarded. In the reported case a host backing a VM with 32 × 1G pages had them replaced with 4 when a Wormhole card was installed.

Pages already present belong to something else, so our requirement is now added on top of them.

## Repeat runs

Adding unconditionally would stack on every invocation, so the number of pages we added is recorded per node under `/run`, and subtracted before computing the new total. A second run therefore converges on the same figure rather than growing.

`/run` is tmpfs and is cleared on boot, which is exactly when `nr_hugepages` resets to the kernel command line value — so the marker and the kernel state expire together and there is nothing to clean up. A count that has been lowered behind our back clamps at zero rather than producing a negative target.

## Why not free_hugepages

It looks like the natural signal, but it cannot work here. The unit is `Type=oneshot` `Before=sysinit.target`, so it runs before anything has claimed a page: at that moment `free_hugepages` equals `nr_hugepages`, and pages deliberately reserved for a VM are indistinguishable from spare ones. Sizing against free would silently under-allocate on exactly the machines this issue is about.

## Testing

`SYSFS_ROOT` and `STATE_DIR` are overridable, both defaulting to the real paths, so the arithmetic can be exercised against a fixture.

`hugepages-setup/test-hugepages-setup.sh` — 10 assertions against a fixture sysfs tree and a stub `lspci`. No hardware and no root required:

- a fresh machine, one card and two cards
- an existing 32-page allocation preserved, with one card and with two
- repeat runs converging instead of stacking
- a simulated reboot (marker cleared, count reset) landing on the same total
- a count lowered behind our back not producing a negative target
- a missing NUMA node still being a hard error

Reverting only the arithmetic while leaving the fixture hooks in place fails exactly the three assertions that encode this bug, and leaves the other seven passing — the original was never wrong on a clean machine, which is why this went unnoticed.

---

Reported with a suggested patch by @shsym. This differs from that suggestion only in reconciling repeat runs; the core change is theirs.

Happy to drop the `/run` marker and take the simpler `current + needed` form if you would rather not carry the state, though a second `systemctl start` would then allocate another 4 pages per card.
